### PR TITLE
address encoding issue with querystring

### DIFF
--- a/src/ConnectWise.js
+++ b/src/ConnectWise.js
@@ -326,11 +326,11 @@ function parameterize(params) {
   var result = [];
   for (var param in params) {
     if (params.hasOwnProperty(param)) {
-      result.push(param + '=' + params[param]);
+      result.push(param + '=' + encodeURIComponent(params[param]));
     }
   }
 
-  return encodeURI('?' + result.join('&'));
+  return '?' + result.join('&');
 }
 
 /**


### PR DESCRIPTION
If would do a search for an email address that has a '+' in the email, I would get unexpected results. Upon investigating, it looks like we could make some improvements to the way conditions are encoded when we enumerate querystring options  