### PR TITLE
Indiv contact types

### DIFF
--- a/src/CompanyAPI/ContactContactTypeAssociations.js
+++ b/src/CompanyAPI/ContactContactTypeAssociations.js
@@ -1,5 +1,5 @@
-var inherits = require('util').inherits,
-  ConnectWise = require('../ConnectWise.js');
+var inherits = require('util').inherits
+var ConnectWise = require('../ConnectWise.js');
 
 /**
  * @typedef {object} ContactContactTypeAssociations

--- a/src/CompanyAPI/ContactContactTypeAssociations.js
+++ b/src/CompanyAPI/ContactContactTypeAssociations.js
@@ -34,6 +34,13 @@ ContactContactTypeAssociations.prototype.update = function (contactId,  associat
   return this.api(path, 'PUT', params);
 };
 
+ContactContactTypeAssociations.prototype.create = function (contactId, params) {
+  var path ='/company/contacts/' + 
+    contactId + '/typeAssociations'
+
+  return this.api(path, 'POST', params);
+};
+
 /**
  * @type {ContactContactTypeAssociations}
  */

--- a/src/CompanyAPI/ContactContactTypeAssociations.js
+++ b/src/CompanyAPI/ContactContactTypeAssociations.js
@@ -1,0 +1,40 @@
+var inherits = require('util').inherits,
+  ConnectWise = require('../ConnectWise.js');
+
+/**
+ * @typedef {object} ContactContactTypeAssociations
+ */
+
+/**
+ *
+ * @param {CWOptions} options
+ * @inherits {ConnectWise}
+ * @constructor
+ */
+function ContactContactTypeAssociations(options) {
+  ConnectWise.apply(this, Array.prototype.slice.call(arguments));
+}
+
+inherits(ContactContactTypeAssociations, ConnectWise);
+
+/**
+ * @param {Params} params
+ * @returns {Promise<ContactTypeAssociation[]>}
+ */
+ContactContactTypeAssociations.prototype.get = function (contactId, params) {
+  var path = '/company/contacts/' + contactId + '/typeAssociations'
+  return this.api(path, 'GET', params);
+};
+
+ContactContactTypeAssociations.prototype.update = function (contactId,  associationId, params) {
+  var path ='/company/contacts/' + 
+    contactId + '/typeAssociations/' + 
+    associationId 
+
+  return this.api(path, 'PUT', params);
+};
+
+/**
+ * @type {ContactContactTypeAssociations}
+ */
+module.exports = ContactContactTypeAssociations;

--- a/src/CompanyAPI/index.js
+++ b/src/CompanyAPI/index.js
@@ -22,12 +22,14 @@ function CompanyAPI(options) {
     _Contacts = require('./Contacts'),
     _Configurations = require('./Configurations'),
     _ContactRelationships = require('./ContactRelationships');
+    _ContactContactTypeAssociations = require('./ContactContactTypeAssociations')
 
   return {
     Companies: new _Companies(options),
     Contacts: new _Contacts(options),
     Configurations: new _Configurations(options),
     ContactRelationships: new _ContactRelationships(options),
+    ContactContactTypeAssociations: new _ContactContactTypeAssociations(options)
   };
 }
 


### PR DESCRIPTION
I've created an endpoint for a recent change to ConnectWise, that is, less than ideal. There's an API for ContactContactTypeAssociation's because they've changed ContactTypes to Contacts to be a many-many association. 

I'm not wild about this direction, but the client I implemented in this PR allows me to interact with it. Happy to reorg it as you see fit. 