### PR TITLE
Correct Accept header syntax

### DIFF
--- a/src/ConnectWise.js
+++ b/src/ConnectWise.js
@@ -189,7 +189,7 @@ function apiPromise(path, method, params, config) {
     const options = {
       url: config.apiUrl + path,
       headers: {
-        'Accept': `application/json; application/vnd.connectwise.com+json; version=${config.apiVersion}`,
+        'Accept': `application/vnd.connectwise.com+json; version=${config.apiVersion}, application/json`,
         'Cache-Control': 'no-cache',
         'Authorization': config.auth,
       },


### PR DESCRIPTION
The syntax used in a409b5be isn't working to select 2019.1, for example.

It seems to be expecting it as the first media type in Accept, since even `application/json, application/vnd.connectwise.com+json; version=${config.apiVersion}` doesn't work.