### PR TITLE
Enable gzip for API calls to ConnectWise

### DIFF
--- a/src/ConnectWise.js
+++ b/src/ConnectWise.js
@@ -195,6 +195,7 @@ function apiPromise(path, method, params, config) {
       },
       method: method,
       timeout: config.timeout,
+      gzip: true,
     };
 
     if (config.clientId) {


### PR DESCRIPTION
For larger responses (such as pulling project tickets), this can lead to fairly decent time improvements.

Didn't see any compelling reasons to make it optional, but happy to if you'd prefer.