### PR TITLE
Add Company Sites Update

### DIFF
--- a/src/CompanyAPI/CompanySites.js
+++ b/src/CompanyAPI/CompanySites.js
@@ -67,4 +67,14 @@ CompanySites.prototype.getCompanySiteById = function (companyId, id) {
   return this.api(`/company/companies/${companyId}/sites/${id}`, 'GET');
 };
 
+/**
+ * @param companyId
+ * @param id
+ * @param {Operations[]} ops
+ * @returns {Promise<CompanySite>}
+ */
+CompanySites.prototype.updateCompanySite = function (companyId, id, ops) {
+  return this.api(`/company/companies/${companyId}/sites/${id}`, 'PATCH', ops);
+};
+
 module.exports = CompanySites;


### PR DESCRIPTION
I've added an Update to the Company Sites part of the API, and followed the variable naming standard in this file. However, the variable naming in this file appears to conflict with the naming used for Teams (https://github.com/covenanttechnologysolutions/connectwise-rest/blob/master/src/CompanyAPI/CompanyTeams.js) - which uses id and teamID, rather than companyId and id. I'm not sure which one could be considered "standard", but I think following what's already been done in this file makes the most sense.