### PR TITLE
Fix Incorrect Endpoint in Documentation for User-Defined Fields Workflow Events

### DIFF
--- a/src/Manage/SystemAPI.ts
+++ b/src/Manage/SystemAPI.ts
@@ -6407,7 +6407,7 @@ export class SystemAPI extends Manage {
     params: CommonParameters = {},
   ): Promise<Array<WorkflowActionUserDefinedField>> {
     return this.request({
-      path: `/system/workflows/userdefinedfields/events${grandparentId}/actions/${parentId}`,
+      path: `/system/workflows/userdefinedfields/events/${grandparentId}/actions/${parentId}`,
       method: 'get',
       params,
     })

--- a/src/ManageTypes.ts
+++ b/src/ManageTypes.ts
@@ -5846,7 +5846,7 @@ export interface paths {
   "/system/workflows/userdefinedfields/events/{grandparentId}": {
     post: operations["postSystemWorkflowsUserdefinedfieldsEventsByGrandparentId"];
   };
-  "/system/workflows/userdefinedfields/events{grandparentId}/actions/{parentId}": {
+  "/system/workflows/userdefinedfields/events/{grandparentId}/actions/{parentId}": {
     get: operations["getSystemWorkflowsUserdefinedfieldsByGrandparentIdActionsByParentId"];
   };
   "/time/accruals": {


### PR DESCRIPTION
I've identified an error in the documentation regarding the endpoint for 'GET /system/workflows/userdefinedfields/events{grandparentId}/actions/{parentId}'.

Current Documentation Issue:
The current endpoint format in the documentation is missing a forward slash before {grandparentId}, making it incorrect.

Proposed Change:
Correct the endpoint to /system/workflows/userdefinedfields/events/{grandparentId}/actions/{parentId}. This ensures the proper syntax is documented, reflecting the actual endpoint structure.