### PR TITLE
Allow string as input type for PatchOperation value

### DIFF
--- a/src/ManageTypes.ts
+++ b/src/ManageTypes.ts
@@ -14202,7 +14202,7 @@ export interface components {
     PatchOperation: {
       op?: string;
       path?: string;
-      value?: { [key: string]: unknown };
+      value?: { [key: string]: unknown } | string;
     };
     Payment: {
       /** Format: int32 */


### PR DESCRIPTION
Strings are allowed for the `value` attribute as per documentation:


| Attribute | Description | Possible values |
|----------|----------|----------|
| op    | The update operation used in the request | add &#124; replace &#124; remove  |
| path | Pathway for the updated field (Case Sensitive)  | summary<br /> company |
| value   | The new value if doing a replace <br />Refer to escaping characters<br />When working with custom fields, you must pass the entire array of custom fields. | String: "Here is my Summary" <br /> Object: { "identifier": "connectwise" }|


https://api-na.myconnectwise.net/v4_6_release/apis/3.0/service/tickets/5000
```json
[
    {
        "op": "replace",
        "path": "summary",
        "value": "New Summary"
    },
    {
        "op": "replace",
        "path": "company",
        "value": {
            "identifier": "New Company"
        }
    },
    {
       "op": "replace",
       "path": "customFields",
       "value": [
            {
                 "id": 5,
                 "caption": "CloudPlus",
                 "type": "Checkbox",
                 "entryMethod": "EntryField",
                 "numberOfDecimals": 0,
                 "value": false
            },
               {          
                 "id": 28,
                 "caption": "test",
                 "type": "Text",
                 "entryMethod": "List",
                 "numberOfDecimals": 0,
                 "value": "test"
            }
        ]
    }
]
```
